### PR TITLE
Refactor: Move inline CSS to dedicated classes

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -13,17 +13,8 @@
     <img
       src="https://daihachi10.github.io/assets/img/logo.webp"
       alt="logo"
-      style="
-        width: 35px;
-        height: 35px;
-        vertical-align: bottom;
-        margin-bottom: 5px;
-        margin-right: 1px;
-        vertical-align: middle;
-      "
-    /><span class="logo-text" style="font-size: 30px; font-weight: bold"
-      >aihachi</span
-    >
+      class="header-logo-img"
+    /><span class="logo-text">aihachi</span>
   </a>
   <button class="toggle-menu-button"></button>
   <div class="header-site-menu">
@@ -37,7 +28,7 @@
           >
             <a
               href="https://daihachi10.github.io/search/"
-              style="padding-left: 5px; max-width: 1200px"
+              class="header-search-link"
               id="header-search-text"
               >search</a
             >

--- a/css/common.css
+++ b/css/common.css
@@ -29,6 +29,24 @@ a {
   text-decoration: none;
 }
 
+.header-logo-img {
+  width: 35px;
+  height: 35px;
+  vertical-align: middle; /* Consolidating vertical-align */
+  margin-bottom: 5px;
+  margin-right: 1px;
+}
+
+.logo-text {
+  font-size: 30px;
+  font-weight: bold;
+}
+
+.header-search-link {
+  padding-left: 5px;
+  max-width: 1200px;
+}
+
 .header {
   background-color: var(--background-color);
   opacity: 100;

--- a/css/index.css
+++ b/css/index.css
@@ -216,6 +216,10 @@ body {
     width: 220px;
     margin-right: 30px;
   }
+
+.first-view-text-p {
+  padding-top: 10px;
+}
   .loginiframe {
     display: none;
   }

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         <div class="first-view-text">
           <h1 data-aos="zoom-in" data-aos-delay="1800">Various</h1>
           <h1 data-aos="zoom-in" data-aos-delay="2000">Programming.</h1>
-          <p data-aos="fade-up" data-aos-delay="2200" style="padding-top: 10px">
+          <p data-aos="fade-up" data-aos-delay="2200" class="first-view-text-p">
             様々なプログラミング。
           </p>
         </div>


### PR DESCRIPTION
I moved inline styles from HTML elements to CSS classes in the following files:
- index.html: Refactored paragraph padding.
- common/header.html: Refactored styles for logo image, logo text, and search link.

Corresponding CSS rules were added to:
- css/index.css
- css/common.css

This change improves maintainability and separates concerns by centralizing styles in CSS files.